### PR TITLE
Admin page for admins to manage their project group

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import './styles/App.css';
 import NavBar from './components/NavBar';
 import GeneralOwnerDashboard from './screens/general/GeneralOwnerDashboard';
+import AdminDashboard from './screens/general/AdminDashboard';
 import Onboarding from './screens/onboarding/Onboarding';
 import Login from './screens/auth/Login';
 import SignUp from './screens/auth/SignUp';
@@ -18,6 +19,7 @@ function App() {
           <Route path="/signup" component={SignUp} />
           <Route path="/onboarding" component={Onboarding} />
           <Route path="/dashboard" component={GeneralOwnerDashboard} />
+          <Route path="/admin" component={AdminDashboard} />
           <Route>Not Found - 404</Route>
         </Switch>
       </div>

--- a/src/lib/adminHelper.js
+++ b/src/lib/adminHelper.js
@@ -1,0 +1,47 @@
+import { getRecordWithPromise } from './request';
+
+// TABLES
+const PERSON_TABLE = 'Person';
+const OWNER_TABLE = 'Owner';
+const PROJECT_GROUP_TABLE = 'Project Group';
+
+// FIELDS
+const ADMIN_OF = 'Admin Of';
+
+const getOwnerFromPerson = async personId => {
+  const recordMap = await getRecordWithPromise(PERSON_TABLE, personId);
+  const { record } = recordMap;
+  const { Owner } = record;
+
+  if (Owner.length !== 1) {
+    throw new Error('Owner returned from person != 1');
+  }
+
+  return Owner[0];
+};
+
+const getAdminTable = async personId => {
+  const ownerId = await getOwnerFromPerson(personId);
+  const recordMap = await getRecordWithPromise(OWNER_TABLE, ownerId);
+  const { record } = recordMap;
+
+  const ownerOfArr = record[ADMIN_OF];
+  if (ownerOfArr.length === 1) {
+    return ownerOfArr[0];
+  }
+
+  return -1;
+};
+
+const getOwnersFromProjectGroup = async groupId => {
+  const recordMap = await getRecordWithPromise(PROJECT_GROUP_TABLE, groupId);
+  const { record } = recordMap;
+  const { Owner } = record;
+
+  const ownersObjects = await Promise.all(
+    Owner.map(ownerId => getRecordWithPromise(OWNER_TABLE, ownerId))
+  );
+  return ownersObjects.map(ownersObject => ownersObject.record);
+};
+
+export { getAdminTable, getOwnersFromProjectGroup };

--- a/src/lib/adminHelper.js
+++ b/src/lib/adminHelper.js
@@ -1,4 +1,15 @@
 import { getRecordWithPromise } from './request';
+import key from './api_key';
+
+const Airtable = require('airtable');
+
+// API KEY will reside in ENV variables later.
+Airtable.configure({
+  endpointUrl: 'https://api.airtable.com',
+  apiKey: key
+});
+
+const base = Airtable.base('appFaOwKhMXrRIQIp');
 
 // TABLES
 const PERSON_TABLE = 'Person';
@@ -20,8 +31,7 @@ const getOwnerFromPerson = async personId => {
   return Owner[0];
 };
 
-const getAdminTable = async personId => {
-  const ownerId = await getOwnerFromPerson(personId);
+const getAdminTable = async ownerId => {
   const recordMap = await getRecordWithPromise(OWNER_TABLE, ownerId);
   const { record } = recordMap;
 
@@ -44,4 +54,34 @@ const getOwnersFromProjectGroup = async groupId => {
   return ownersObjects.map(ownersObject => ownersObject.record);
 };
 
-export { getAdminTable, getOwnersFromProjectGroup };
+const removeOwnerFromProjectGroup = async (id, newOwners) => {
+  return new Promise((resolve, reject) => {
+    base(PROJECT_GROUP_TABLE).update(
+      [
+        {
+          id,
+          fields: {
+            Owner: newOwners
+          }
+        }
+      ],
+      function(err) {
+        if (err) {
+          console.error(err);
+          reject(err);
+        }
+        resolve(true);
+        // records.forEach(function(record) {
+        //   console.log(record.get('Owner'));
+        // });
+      }
+    );
+  });
+};
+
+export {
+  getAdminTable,
+  getOwnersFromProjectGroup,
+  getOwnerFromPerson,
+  removeOwnerFromProjectGroup
+};

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -10,7 +10,6 @@ const Airtable = require('airtable');
 const base = new Airtable({ apiKey: key }).base(BASE_ID);
 
 const EMAIL_FIELD = 'Email';
-const ID_FIELD = 'ID';
 const PASSWORD_FIELD = 'Password';
 const GRID_VIEW = 'Grid view';
 const NUM_RECORDS = 1;
@@ -35,7 +34,8 @@ const loginUser = (email, passwordHash) => {
             const recordEmail = record.get(EMAIL_FIELD);
             if (recordEmail === email) {
               if (record.get(PASSWORD_FIELD) === passwordHash) {
-                cookies.set(LOGIN_TOKEN_NAME, record.get(ID_FIELD));
+                const personId = record.get('Person')[0];
+                cookies.set(LOGIN_TOKEN_NAME, personId);
                 resolve({ match: true, found: true });
               } else {
                 resolve({ match: false, found: true });

--- a/src/screens/general/AdminDashboard.js
+++ b/src/screens/general/AdminDashboard.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import Card from './Card';
+import '../../styles/AdminDashboard.css';
+import { getLoggedInUserId } from '../../lib/auth';
+import {
+  getAdminTable,
+  getOwnersFromProjectGroup
+} from '../../lib/adminHelper';
+
+export default class AdminDashboard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      access: false,
+      owners: []
+    };
+  }
+
+  async componentDidMount() {
+    const personId = getLoggedInUserId();
+    if (personId == null) {
+      return;
+    }
+
+    const adminGroupId = await getAdminTable(personId);
+    if (adminGroupId === -1) {
+      return;
+    }
+
+    const owners = await getOwnersFromProjectGroup(adminGroupId);
+    try {
+      this.setState({
+        access: true,
+        owners: owners.filter(owner => owner.Person[0] !== personId)
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  render() {
+    const { access } = this.state;
+    if (!access) {
+      return (
+        <div className="dashboardCont">
+          <h3>ACCESS DENIED</h3>
+        </div>
+      );
+    }
+    const { owners } = this.state;
+    return (
+      <div className="dashboardCont">
+        <h3>Admin Dashboard</h3>
+        <p>Shhh keep it a secret</p>
+        <div className="card-holder">
+          {owners.map(owner => {
+            return <Card name={owner.ID} />;
+          })}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/screens/general/AdminDashboard.js
+++ b/src/screens/general/AdminDashboard.js
@@ -17,7 +17,8 @@ export default class AdminDashboard extends React.Component {
     this.state = {
       access: false,
       adminGroupId: -1,
-      owners: []
+      owners: [],
+      isReady: false
     };
   }
 
@@ -39,7 +40,8 @@ export default class AdminDashboard extends React.Component {
         access: true,
         adminId: ownerId,
         adminGroupId,
-        owners: owners.filter(owner => owner.Person[0] !== personId)
+        owners: owners.filter(owner => owner.Person[0] !== personId),
+        isReady: true
       });
     } catch (err) {
       console.error(err);
@@ -64,7 +66,16 @@ export default class AdminDashboard extends React.Component {
   }
 
   render() {
-    const { access } = this.state;
+    const { access, isReady } = this.state;
+
+    if (!isReady) {
+      return (
+        <div className="dashboardCont">
+          <h3>Loading...</h3>
+        </div>
+      );
+    }
+
     if (!access) {
       return (
         <div className="dashboardCont">

--- a/src/screens/general/AdminDashboard.js
+++ b/src/screens/general/AdminDashboard.js
@@ -4,14 +4,19 @@ import '../../styles/AdminDashboard.css';
 import { getLoggedInUserId } from '../../lib/auth';
 import {
   getAdminTable,
-  getOwnersFromProjectGroup
+  getOwnersFromProjectGroup,
+  removeOwnerFromProjectGroup,
+  getOwnerFromPerson
 } from '../../lib/adminHelper';
+
+const OWNER_ID_FIELD = 'Owner ID';
 
 export default class AdminDashboard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       access: false,
+      adminGroupId: -1,
       owners: []
     };
   }
@@ -22,7 +27,8 @@ export default class AdminDashboard extends React.Component {
       return;
     }
 
-    const adminGroupId = await getAdminTable(personId);
+    const ownerId = await getOwnerFromPerson(personId);
+    const adminGroupId = await getAdminTable(ownerId);
     if (adminGroupId === -1) {
       return;
     }
@@ -31,11 +37,30 @@ export default class AdminDashboard extends React.Component {
     try {
       this.setState({
         access: true,
+        adminId: ownerId,
+        adminGroupId,
         owners: owners.filter(owner => owner.Person[0] !== personId)
       });
     } catch (err) {
       console.error(err);
     }
+  }
+
+  async removeUser(idToRemove) {
+    console.log(idToRemove);
+    const { adminGroupId, adminId } = this.state;
+    let { owners } = this.state;
+    let ownerIds = owners.map(owner => owner[OWNER_ID_FIELD]);
+
+    // FILTER
+    ownerIds = ownerIds.filter(ownerId => ownerId !== idToRemove);
+    owners = owners.filter(owner => owner[OWNER_ID_FIELD] !== idToRemove);
+    ownerIds.push(adminId);
+
+    await removeOwnerFromProjectGroup(adminGroupId, ownerIds);
+    this.setState({
+      owners
+    });
   }
 
   render() {
@@ -51,11 +76,22 @@ export default class AdminDashboard extends React.Component {
     return (
       <div className="dashboardCont">
         <h3>Admin Dashboard</h3>
-        <p>Shhh keep it a secret</p>
         <div className="card-holder">
-          {owners.map(owner => {
-            return <Card name={owner.ID} />;
-          })}
+          {owners.length >= 1 ? (
+            owners.map(owner => {
+              return (
+                <Card
+                  name={owner.ID}
+                  callback={idToRemove => this.removeUser(idToRemove)}
+                  ownerId={owner[OWNER_ID_FIELD]}
+                />
+              );
+            })
+          ) : (
+            <div className="white-text">
+              No owners to be displayed in this project group
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/screens/general/Card.js
+++ b/src/screens/general/Card.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import '../../styles/Card.css';
+
+function Card({ name, callback }) {
+  return (
+    <div className="card">
+      <h3>{name}</h3>
+      <button type="button" onClick={callback} className="card-button">
+        {' '}
+        Remove from Group{' '}
+      </button>
+    </div>
+  );
+}
+
+export default Card;

--- a/src/screens/general/Card.js
+++ b/src/screens/general/Card.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import '../../styles/Card.css';
 
-function Card({ name, callback }) {
+function Card({ name, callback, ownerId }) {
   return (
     <div className="card">
       <h3>{name}</h3>
-      <button type="button" onClick={callback} className="card-button">
-        {' '}
-        Remove from Group{' '}
+      <button
+        type="button"
+        onClick={() => callback(ownerId)}
+        className="card-button"
+      >
+        Remove from Group
       </button>
     </div>
   );

--- a/src/styles/AdminDashboard.css
+++ b/src/styles/AdminDashboard.css
@@ -1,3 +1,7 @@
 .card-holder {
   display: flex;
 }
+
+.white-text {
+  color: white;
+}

--- a/src/styles/AdminDashboard.css
+++ b/src/styles/AdminDashboard.css
@@ -1,0 +1,3 @@
+.card-holder {
+  display: flex;
+}

--- a/src/styles/Card.css
+++ b/src/styles/Card.css
@@ -1,0 +1,16 @@
+.card {
+  background-color: darkgrey;
+  background-color: gray;
+  border-radius: 4px;
+  margin: 0.5em;
+  padding: 1em;
+}
+
+.card-button {
+  background-color: black;
+  color: white;
+  padding: 0.5em 1.2em;
+  border-radius: 4px;
+  border: none;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Allow Admins to remove owners from their project groups

An admin owner can view a page that lets them see and manage the owners in their project group. For now, the only action admins can take is to remove an owner from their group
### Related PRs

-

### Migrations

-

### Tests Performed, Edge Cases

-

### Screenshots

![image](https://user-images.githubusercontent.com/28598778/67655885-640e5f80-f90f-11e9-8f48-af57ce5a0e89.png)


CC: @aivantg
