### PR TITLE
Update Paypal Payment flow

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -18,7 +18,8 @@ const constants = {
   // TRANSACTION TYPES AND STATUS
   BILL_TYPE: 'Bill',
   ONLINE_PAYMENT_TYPE: 'Online Payment',
-  COMPLETED_STATUS: 'Completed'
+  COMPLETED_STATUS: 'Completed',
+  PENDING_STATUS: 'Pending'
 };
 
 export default constants;

--- a/src/lib/paypal.js
+++ b/src/lib/paypal.js
@@ -1,10 +1,15 @@
 import { createPayment, updateOwner, updateSubscriberBill } from './request';
 import constants from '../constants';
 
-const { BILL_PAYMENT_TYPE, BUY_SHARES_TYPE } = constants;
+const {
+  BILL_PAYMENT_TYPE,
+  BUY_SHARES_TYPE,
+  COMPLETED_STATUS,
+  PENDING_STATUS
+} = constants;
 
-const createPaymentRecord = async record => {
-  /*
+/*
+  Schema of Payment Table
       {
         "fields": {
           "Owner": [
@@ -19,8 +24,15 @@ const createPaymentRecord = async record => {
         }
       }
     */
-  const id = await createPayment(record);
-  return id;
+
+const dollarsToCents = dollars => {
+  return parseFloat(dollars, 10) * 100;
+};
+
+const getTotalBalanceFromBills = pendingBills => {
+  return pendingBills
+    .map(pendingBill => pendingBill.Balance)
+    .reduce((a, b) => a + b, 0);
 };
 
 const recordShareBuySuccess = async (details, data, values) => {
@@ -64,17 +76,26 @@ const recordShareBuySuccess = async (details, data, values) => {
     TODO(dfangshuo): retry logic
   */
   try {
-    const paymentId = await createPaymentRecord(record);
+    const paymentId = await createPayment(record);
     console.log(paymentId);
+    return paymentId;
   } catch (err) {
     console.error(err);
+    return null;
   }
 };
 
-const recordBillPaymentSuccess = async (details, data, bill) => {
-  console.log('I WAS IN ');
+const constructPaymentRecord = (details, data, bill) => {
   /*
-        DETAILS FIELDS
+        @params: data FIELDS
+        
+        orderID: "SOME ORDER ID"
+        payerID: "SOME PAYER ID"
+     
+  */
+
+  /*
+        @params: details FIELDS
   
         create_time: "2019-11-12T04:44:42Z"
         id: "SOME_ID_HERE"
@@ -97,51 +118,41 @@ const recordBillPaymentSuccess = async (details, data, bill) => {
   
         ----
   
-        purchase_units (EXPANDED)
-  
-        amount: 
-            value: "SOME VALUE (IN DOLLARS)", 
-            currency_code: "SOME CURRENCY CODE"
-        payee: 
-            email_address: "SOME EMAIL ADDREESS", 
-            merchant_id: "SOME MERCHANT ID"
-        payments: 
-            captures: [{
-                amount: {value: "SOME VALUE (IN DOLLARS)", currency_code: "SOME CURRENCY CODE"}
-                create_time: "2019-11-12T04:58:14Z"
-                final_capture: true/false
-                id: "SOME ID"
-                links: (3) [{…}, {…}, {…}]
-                seller_protection: {status: "SOME STATUS", dispute_categories: Array(2)}
-                status: "SOME STATUS"
-                update_time: "2019-11-12T04:58:14Z"
-            }]
-              
-            reference_id: "SOME REFERENCE ID"
-        shipping:
-            address:
-                address_line_1: "X X STREET"
-                admin_area_1: "SOME STATE"
-                admin_area_2: "SOME AREA"
-                country_code: "SOME COUNTRY"
-                postal_code: "POSTAL CODE HERE"
-            name:
-                full_name: "FULL NAME HERE"
-        
-        status: "SOME STATUS HERE"
-        update_time: "2019-11-12T04:58:14Z"
-     */
-
-  /*
-        DATA FIELDS
-        
-        orderID: "SOME ORDER ID"
-        payerID: "SOME PAYER ID"
-     
-     */
-
+          purchase_units (EXPANDED from above)
+    
+          amount: 
+              value: "SOME VALUE (IN DOLLARS)", 
+              currency_code: "SOME CURRENCY CODE"
+          payee: 
+              email_address: "SOME EMAIL ADDREESS", 
+              merchant_id: "SOME MERCHANT ID"
+          payments: 
+              captures: [{
+                  amount: {value: "SOME VALUE (IN DOLLARS)", currency_code: "SOME CURRENCY CODE"}
+                  create_time: "2019-11-12T04:58:14Z"
+                  final_capture: true/false
+                  id: "SOME ID"
+                  links: (3) [{…}, {…}, {…}]
+                  seller_protection: {status: "SOME STATUS", dispute_categories: Array(2)}
+                  status: "SOME STATUS"
+                  update_time: "2019-11-12T04:58:14Z"
+              }]
+                
+              reference_id: "SOME REFERENCE ID"
+          shipping:
+              address:
+                  address_line_1: "X X STREET"
+                  admin_area_1: "SOME STATE"
+                  admin_area_2: "SOME AREA"
+                  country_code: "SOME COUNTRY"
+                  postal_code: "POSTAL CODE HERE"
+              name:
+                  full_name: "FULL NAME HERE"
+          
+          status: "SOME STATUS HERE"
+          update_time: "2019-11-12T04:58:14Z"
+    */
   const owner = bill['Subscriber Owner'];
-  const billId = bill.ID;
 
   const { orderID, payerID } = data;
 
@@ -154,11 +165,12 @@ const recordBillPaymentSuccess = async (details, data, bill) => {
 
   const { address, name } = shipping;
   const addressToSave = `${address.address_line_1}, ${address.admin_area_2} ${address.country_code} ${address.admin_area_1} ${address.postal_code}`;
-  const amountInCents = parseFloat(amount.value, 10) * 100;
-  const record = {
+  // const amountInCents = dollarsToCents({ TODO: APPROPRIATE VALUE HERE });
+  const amountInCents = bill.Balance; // TODO: currently assumes entire bill is paid
+  const paymentRecord = {
     Owner: [owner],
     Status: status,
-    'Subscriber Bill': [billId],
+    'Subscriber Bill': [bill.ID],
     'Order ID': orderID,
     'Payer ID': payerID,
     Amount: amountInCents,
@@ -173,27 +185,70 @@ const recordBillPaymentSuccess = async (details, data, bill) => {
   };
 
   if (id !== orderID) {
-    record.fields.Notes = 'id and order id mismatch';
+    paymentRecord.Notes = 'id and order id mismatch';
   }
-  /*
-      TODO(dfangshuo): another important place where retry logic might be important
-      
-      If paypal goes through but the payment record wasn't created for some reason, 
-      it could cause problems
-    */
-
-  try {
-    const paymentId = await createPaymentRecord(record);
-    console.log(paymentId);
-  } catch (err) {
-    console.error(err);
-  }
-
-  const newBalance = bill.Balance - amountInCents;
-  const updatedBill = {
-    Balance: newBalance
-  };
-  updateSubscriberBill(billId, updatedBill);
+  return paymentRecord;
 };
 
-export { recordShareBuySuccess, recordBillPaymentSuccess };
+// records bill payment success, updating the bill balance
+// (and status, if necessary)
+// returns the id of the updated bill upon success
+const recordBillPaymentSuccess = async (details, data, bill) => {
+  const paymentRecord = constructPaymentRecord(details, data, bill);
+  try {
+    const paymentId = await createPayment(paymentRecord);
+    console.log(paymentId);
+  } catch (err) {
+    /*
+        TODO(dfangshuo): another important place where retry logic might be important
+        
+        If paypal goes through but the payment record wasn't created for some reason, 
+        it could cause problems
+    */
+    console.error(err);
+    return err;
+  }
+
+  // update bill
+  // TODO: currently will always be 0, because amountInCents === bill.Balance
+  // may not be the case for partial payments
+  const newBalance = bill.Balance - paymentRecord.Amount;
+  return updateSubscriberBill(bill.ID, {
+    Balance: newBalance,
+    Status: newBalance === 0 ? COMPLETED_STATUS : PENDING_STATUS
+  });
+};
+
+const recordPendingBillsPaymentSuccess = async (
+  details,
+  data,
+  pendingBills
+) => {
+  const { amount } = details.purchase_units[0]; // assumes purchase_units is only of length 1
+  const amountPaidInCents = dollarsToCents(amount.value);
+  const totalBalance = getTotalBalanceFromBills(pendingBills);
+
+  // TODO: for now, enforces that the amount paid === total balance
+  // to be changed when implementing functionality that allows you to pay
+  // less than the total amount
+  if (amountPaidInCents !== totalBalance) {
+    return new Error(
+      `Amount paid $${amountPaidInCents} not equal to total balance $${totalBalance}`
+    );
+  }
+
+  // will surface errors from recordBillPaymentSuccess
+  await Promise.all(
+    pendingBills.map(pendingBill =>
+      recordBillPaymentSuccess(details, data, pendingBill)
+    )
+  );
+
+  return null;
+};
+
+export {
+  getTotalBalanceFromBills,
+  recordShareBuySuccess,
+  recordPendingBillsPaymentSuccess
+};

--- a/src/lib/subscriberUtils.js
+++ b/src/lib/subscriberUtils.js
@@ -70,27 +70,32 @@ const getSubscriberBills = async loggedInUserId => {
 
     if (billObjects) {
       billObjects.forEach(billObject => {
-        const bill = {
-          ID: billObject.ID,
-          'Subscriber Owner': billObject['Subscriber Owner'][0], // assumes exactly 1 subscriber owner
-          'Transaction Date': billObject['Statement Date'],
-          'Start Date': billObject['Start Date'],
-          'End Date': billObject['End Date'],
-          'Rate Schedule': billObject['Rate Schedule'],
-          'Estimated Rebate': billObject['Estimated Rebate'],
-          'Total Estimated Rebate': billObject['Total Estimated Rebate'],
-          'Amount Due on Previous': billObject['Amount Due on Previous'],
-          'Amount Received Since Previous':
-            billObject['Amount Received Since Previous'],
-          'Amount Due': billObject['Amount Due'],
-          Status: billObject.Status,
-          Balance: billObject.Balance,
-          Type: BILL_TYPE // Type is a local variable inserted to distinguish between bill payments and online payments
-        };
-
-        transactions.push(bill);
+        transactions.push({
+          transactionDate: billObject['Statement Date'],
+          startDate: billObject['Start Date'],
+          amountDue: billObject['Amount Due'],
+          status: billObject.Status,
+          balance: billObject.Balance,
+          type: BILL_TYPE // Type is a local variable inserted to distinguish between bill payments and online payments
+        });
         if (billObject.Status !== COMPLETED_STATUS) {
-          pendingBills.push(bill);
+          pendingBills.push({
+            ID: billObject.ID,
+            'Subscriber Owner': billObject['Subscriber Owner'][0], // assumes exactly 1 subscriber owner
+            'Transaction Date': billObject['Statement Date'],
+            'Start Date': billObject['Start Date'],
+            'End Date': billObject['End Date'],
+            'Rate Schedule': billObject['Rate Schedule'],
+            'Estimated Rebate': billObject['Estimated Rebate'],
+            'Total Estimated Rebate': billObject['Total Estimated Rebate'],
+            'Amount Due on Previous': billObject['Amount Due on Previous'],
+            'Amount Received Since Previous':
+              billObject['Amount Received Since Previous'],
+            'Amount Due': billObject['Amount Due'],
+            Status: billObject.Status,
+            Balance: billObject.Balance,
+            Type: BILL_TYPE // Type is a local variable inserted to distinguish between bill payments and online payments
+          });
         }
       });
     }
@@ -98,19 +103,19 @@ const getSubscriberBills = async loggedInUserId => {
     if (paymentObjects) {
       paymentObjects.forEach(paymentObject => {
         transactions.push({
-          'Transaction Date': convertPaypalDateTimeToDate(
+          transactionDate: convertPaypalDateTimeToDate(
             paymentObject['Payment Create Time']
           ),
-          Type: ONLINE_PAYMENT_TYPE, // Type is a local variable inserted to distinguish between bill payments and online payments
-          Amount: paymentObject.Amount,
-          Status: paymentObject.Status
+          amount: paymentObject.Amount,
+          status: paymentObject.Status,
+          type: ONLINE_PAYMENT_TYPE // Type is a local variable inserted to distinguish between bill payments and online payments
         });
       });
     }
     transactions.sort((a, b) => {
-      return new Date(b['Transaction Date']) - new Date(a['Transaction Date']);
+      return new Date(b.transactionDate) - new Date(a.transactionDate);
     });
-    
+
     return { transactions, pendingBills };
   } catch (err) {
     console.log(err);

--- a/src/lib/subscriberUtils.js
+++ b/src/lib/subscriberUtils.js
@@ -110,13 +110,7 @@ const getSubscriberBills = async loggedInUserId => {
     transactions.sort((a, b) => {
       return new Date(b['Transaction Date']) - new Date(a['Transaction Date']);
     });
-
-    for (let i = 0; i < transactions.length; i += 1) {
-      if (transactions[i].Type === BILL_TYPE) {
-        transactions[i]['Is Latest'] = true;
-        break;
-      }
-    }
+    
     return { transactions, pendingBills };
   } catch (err) {
     console.log(err);

--- a/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardAllBillsTable.js
+++ b/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardAllBillsTable.js
@@ -17,10 +17,10 @@ const renderAllBillsHeader = headerText => {
 const createFullPaymentTransaction = transaction => {
   return {
     balance: '$0.00',
-    statementDate: dateToDateString(transaction['Transaction Date']),
-    description: transaction.Type,
-    status: formatStatus(transaction.Status),
-    payment: `$${centsToDollars(transaction.Amount)}`
+    statementDate: dateToDateString(transaction.transactionDate),
+    description: transaction.type,
+    status: formatStatus(transaction.status),
+    payment: `$${centsToDollars(transaction.amount)}`
 
     /*
             Commented out data fields potentially useful for dashbaord (future changes)
@@ -40,11 +40,11 @@ const createFullPaymentTransaction = transaction => {
 
 const createFullBillTransaction = transaction => {
   return {
-    balance: `$${centsToDollars(transaction.Balance)}`,
-    statementDate: dateToDateString(transaction['Transaction Date']),
-    description: `${dateToFullMonth(transaction['Start Date'])} Power Bill`,
-    status: transaction.Status,
-    amtDue: `$${centsToDollars(transaction['Amount Due'])}`
+    balance: `$${centsToDollars(transaction.balance)}`,
+    statementDate: dateToDateString(transaction.transactionDate),
+    description: `${dateToFullMonth(transaction.startDate)} Power Bill`,
+    status: transaction.status,
+    amtDue: `$${centsToDollars(transaction.amountDue)}`
 
     /*
             Commented out data fields potentially useful for dashbaord (future changes)
@@ -67,7 +67,7 @@ export default class SubscriberOwnerDashboardAllBillsTable extends React.Compone
     super(props);
     const { transactions } = this.props;
     const data = transactions.map(t =>
-      t.Type === ONLINE_PAYMENT_TYPE
+      t.type === ONLINE_PAYMENT_TYPE
         ? createFullPaymentTransaction(t)
         : createFullBillTransaction(t)
     );

--- a/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardMainView.js
+++ b/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardMainView.js
@@ -24,22 +24,22 @@ const renderCondensedBillDisplayHeader = headerText => {
 
 const createCondensedPaymentTransaction = transaction => {
   return {
-    startDate: transaction['Start Date'],
-    statementDate: formatDate(transaction['Transaction Date']),
-    description: transaction.Type,
-    status: formatStatus(transaction.Status),
-    payment: `$${centsToDollars(transaction.Amount)}`
+    startDate: transaction.startDate,
+    statementDate: formatDate(transaction.transactionDate),
+    description: transaction.type,
+    status: formatStatus(transaction.status),
+    payment: `$${centsToDollars(transaction.amount)}`
   };
 };
 
 const createCondensedBillTransaction = transaction => {
   return {
-    balance: transaction.Balance,
-    startDate: transaction['Start Date'],
-    statementDate: formatDate(transaction['Transaction Date']),
-    description: `${dateToFullMonth(transaction['Start Date'])} Power Bill`,
-    status: transaction.Status,
-    amtDue: `$${centsToDollars(transaction['Amount Due'])}`
+    balance: transaction.balance,
+    startDate: transaction.startDate,
+    statementDate: formatDate(transaction.transactionDate),
+    description: `${dateToFullMonth(transaction.startDate)} Power Bill`,
+    status: transaction.status,
+    amtDue: `$${centsToDollars(transaction.amountDue)}`
   };
 };
 
@@ -49,7 +49,7 @@ export default class SubscriberOwnerDashboardMainView extends React.Component {
     const { transactions } = this.props;
     this.state = {
       data: transactions.map(t =>
-        t.Type === ONLINE_PAYMENT_TYPE
+        t.type === ONLINE_PAYMENT_TYPE
           ? createCondensedPaymentTransaction(t)
           : createCondensedBillTransaction(t)
       )

--- a/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardMainView.js
+++ b/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardMainView.js
@@ -5,7 +5,10 @@ import '../../../styles/SubscriberOwnerDashboard.css';
 import '../../../styles/SubscriberOwnerDashboardMainView.css';
 import { centsToDollars, formatStatus } from '../../../lib/subscriberUtils';
 import { dateToFullMonth, formatDate } from '../../../lib/dateUtils';
-import { getTotalBalanceFromBills, recordPendingBillsPaymentSuccess } from '../../../lib/paypal';
+import {
+  getTotalBalanceFromBills,
+  recordPendingBillsPaymentSuccess
+} from '../../../lib/paypal';
 
 import constants from '../../../constants';
 
@@ -45,7 +48,11 @@ export default class SubscriberOwnerDashboardMainView extends React.Component {
     super(props);
     const { transactions } = this.props;
     this.state = {
-      latestBill: transactions.filter(bill => bill['Is Latest'])[0]
+      data: transactions.map(t =>
+        t.Type === ONLINE_PAYMENT_TYPE
+          ? createCondensedPaymentTransaction(t)
+          : createCondensedBillTransaction(t)
+      )
     };
   }
 
@@ -67,18 +74,9 @@ export default class SubscriberOwnerDashboardMainView extends React.Component {
   };
 
   render() {
-    const { transactions, callback } = this.props;
-    let { latestBill } = this.state;
+    const { callback } = this.props;
+    const { data } = this.state;
 
-    const data = transactions.map(t =>
-      t.Type === ONLINE_PAYMENT_TYPE
-        ? createCondensedPaymentTransaction(t)
-        : createCondensedBillTransaction(t)
-    );
-
-    if (!latestBill) {
-      latestBill = { Balance: 0 };
-    }
     const { pendingBills } = this.props;
     const totalBalance = getTotalBalanceFromBills(pendingBills);
     return (

--- a/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardMainView.js
+++ b/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardMainView.js
@@ -5,7 +5,7 @@ import '../../../styles/SubscriberOwnerDashboard.css';
 import '../../../styles/SubscriberOwnerDashboardMainView.css';
 import { centsToDollars, formatStatus } from '../../../lib/subscriberUtils';
 import { dateToFullMonth, formatDate } from '../../../lib/dateUtils';
-import { recordBillPaymentSuccess } from '../../../lib/paypal';
+import { getTotalBalanceFromBills, recordPendingBillsPaymentSuccess } from '../../../lib/paypal';
 
 import constants from '../../../constants';
 
@@ -59,8 +59,8 @@ export default class SubscriberOwnerDashboardMainView extends React.Component {
 
   onPaypalPaymentSuccess = async (details, data) => {
     try {
-      const { latestBill } = this.state;
-      await recordBillPaymentSuccess(details, data, latestBill);
+      const { pendingBills } = this.props;
+      await recordPendingBillsPaymentSuccess(details, data, pendingBills);
     } catch (err) {
       console.error(err);
     }
@@ -80,9 +80,7 @@ export default class SubscriberOwnerDashboardMainView extends React.Component {
       latestBill = { Balance: 0 };
     }
     const { pendingBills } = this.props;
-    const totalBalance = pendingBills
-      .map(pendingBill => pendingBill.Balance)
-      .reduce((a, b) => a + b, 0);
+    const totalBalance = getTotalBalanceFromBills(pendingBills);
     return (
       <div className="subscriber-dash-outer-container">
         <h3>My Finances</h3>
@@ -103,7 +101,8 @@ export default class SubscriberOwnerDashboardMainView extends React.Component {
                   </div>
                   <div className="balance-nums-line">
                     <p className="line-item descrip">Upcoming</p>
-                    <p className="line-item">$0.00</p>
+                    <p className="line-item">$0.00</p>{' '}
+                    {/* TODO: currently assumes all bills due now */}
                   </div>
                   <br />
                   <br />

--- a/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardMainView.js
+++ b/src/screens/general/SubscriberOwnerDashboard/SubscriberOwnerDashboardMainView.js
@@ -117,13 +117,18 @@ export default class SubscriberOwnerDashboardMainView extends React.Component {
                 <br />
                 <br />
                 <div className="subscriber-dashboard-paypal-component">
-                  <PayPalButton
-                    amount={centsToDollars(totalBalance)}
-                    onSuccess={this.onPaypalPaymentSuccess}
-                    options={{
-                      clientId
-                    }}
-                  />
+                  {totalBalance === 0 ? null : (
+                    <PayPalButton
+                      amount={centsToDollars(totalBalance)}
+                      onSuccess={this.onPaypalPaymentSuccess}
+                      options={{
+                        clientId
+                      }}
+                      style={{
+                        color: 'black'
+                      }}
+                    />
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Update Paypal Payment flow

[//]: # (Describe your feature here)
The original implementation of Paypal payments only allows you to pay your latest bill. This means that if you have multiple unpaid bills, you can still only pay for your latest bill, and must repeatedly pay to clear multiple bills.

This PR changes that by making your balance be the total outstanding balance of multiple bills, meaning if you have multiple bills, you can pay for them all at once.

The limitation of the current implementation is a step in the right direction but as it is right now, you have to pay for the full amount owed. This means that if you have 3 unowed bills totaling to $281.21 let's say, you have to make a payment of $281.21. There are no partial payments supported. *The plan is to change this in a future PR.*

Additionally, a payment that pays multiple bills records a billl payment for each bill. Aka if you pay $281.21 bills for 2 bills that aree $200 and $82.21 respectivelly, the payment is logged into the Payment table as 2 payments of $200 and $82.21, with the same paypal metadata (because these were paid at the same time). *This might also be changed in the future*

This PR also updates a bill's status to complete once a bill is successfully paid (this was not implemeented before).

*also updated the styling of the paypal button and resolved the struct capitalization issue from https://github.com/calblueprint/peoplepower-web/pull/54

### Related PRs

[//]: # (Optional - any related PRs you're waiting on, or PRs that will conflict, etc)

### Migrations

[//]: # (Optional - if you added anything to the database through migration[s])

### Tests Performed, Edge Cases

[//]: # (If you made changes/additions to `airtable.js` or `request.js`,) 
[//]: # (make sure you update/add [at least 1] corresponding unit tests in)
[//]: # (`airtable.spec.js` or `request.spec.js`)

### Screenshots

[//]: # (Add screenshots!!! If you'd like)

CC: @aivantg @dfangshuo
