### PR TITLE
Fixed Community Posting Bug

### DIFF
--- a/src/screens/shared/Community.js
+++ b/src/screens/shared/Community.js
@@ -15,14 +15,6 @@ class Community extends React.Component {
     };
   }
 
-  addTempCard = announcement => {
-    const { cards } = this.state;
-    const updatedCards = [announcement, ...cards];
-    this.setState({
-      cards: updatedCards
-    });
-  };
-
   render() {
     const {
       announcements,
@@ -39,9 +31,7 @@ class Community extends React.Component {
       <div className="dashboard community">
         <div className="cont">
           <h1>Project News</h1>
-          {isAdmin(credentials) ? (
-            <AddAnnouncement owner={owner} updateCards={this.addTempCard} />
-          ) : null}
+          {isAdmin(credentials) ? <AddAnnouncement owner={owner} /> : null}
           <AnnouncementList
             announcements={announcements}
             css={isAdmin(credentials) ? '' : 'non-admin-height'}

--- a/src/screens/shared/components/AddAnnouncement.js
+++ b/src/screens/shared/components/AddAnnouncement.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import '../../../styles/Community.css';
 import { createAnnouncement } from '../../../lib/airtable/request';
+import { refreshUserData } from '../../../lib/userDataUtils';
 
 const STATUS_ERR = -1;
 const STATUS_IN_PROGRESS = 0;
@@ -37,10 +38,11 @@ export default class AddAnnouncement extends React.Component {
       return;
     }
 
-    const { owner, updateCards } = this.props;
+    const { owner } = this.props;
     const newMessage = {
-      author: owner.id,
-      projectGroupId: [owner.projectGroupId],
+      authorId: [owner.id],
+      // We don't need to put this value below in the array because it's already an array
+      projectGroupId: owner.projectGroupId,
       message
     };
 
@@ -51,8 +53,7 @@ export default class AddAnnouncement extends React.Component {
       message: '',
       submitProgress: STATUS_SUCCESS
     });
-
-    updateCards(newMessage);
+    await refreshUserData(owner.id);
   };
 
   render() {


### PR DESCRIPTION
[//]: # "These comments meant for your reference, they are invisible and don't need to be deleted"

## What's new in this PR?

Fixed bug where admins couldn't create community posts. 

Causes: 
- `author` needed to be renamed to `authorId` because it's a linked field
- `projectGroupId` was being set to a value that was an array inside of an array because `owner.projectGroupId` was already an array type. A confusing side effect of how airtable does linked records. 

Also added a call to refresh data after making a new announcement (which matches the flow across the app. After creating a new post, it will pull new data, refreshing Redux, and consequently updating the parent component by providing it new props.)

Undefined errors in airtable.js happen when it can't find a column with the right name. I've created issues in the schema generator repo to make the whole linked record array columns clearer as well as the undefined errors more clear. Follow here: https://github.com/aivantg/airtable-schema-generator/issues

### Tests Performed, Edge Cases

Made a few test posts, no errors!

CC: @dfangshuo
