### PR TITLE
nick/reformat-arrows

### DIFF
--- a/src/screens/general/BuyShares.js
+++ b/src/screens/general/BuyShares.js
@@ -76,9 +76,9 @@ class BuyShares extends React.PureComponent {
           <div className="left-button">
             <Link to="/investment">
               <img
-                className="button right-arrow-button"
+                className="button left-arrow-button"
                 src={LeftArrow}
-                alt="back arrow"
+                alt="left arrow"
               />
             </Link>
           </div>

--- a/src/screens/subscriber/components/BillingAllTransactions.js
+++ b/src/screens/subscriber/components/BillingAllTransactions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import '../../../styles/SubscriberOwnerDashboard.css';
 import '../../../styles/SubscriberOwnerDashboardAllBillsView.css';
 import TransactionsTable from './TransactionsTable';
-import RightArrow from '../../../assets/right_arrow.png';
+import LeftArrow from '../../../assets/left_arrow.png';
 
 export default class BillingAllTransactions extends React.PureComponent {
   render() {
@@ -16,9 +16,9 @@ export default class BillingAllTransactions extends React.PureComponent {
         >
           <div className="subscriber-back-button-container">
             <img
-              className="button right-arrow-button-flipped"
-              src={RightArrow}
-              alt="right arrow"
+              className="button left-arrow-button"
+              src={LeftArrow}
+              alt="left arrow"
             />
           </div>
         </button>

--- a/src/screens/subscriber/components/BillingPayment.js
+++ b/src/screens/subscriber/components/BillingPayment.js
@@ -9,7 +9,7 @@ import {
 } from '../../../lib/subscriberUtils';
 import LoadingComponent from '../../../components/LoadingComponent';
 import '../../../styles/BillingPayment.css';
-import RightArrow from '../../../assets/right_arrow.png';
+import LeftArrow from '../../../assets/left_arrow.png';
 import { recordBillPayment } from '../../../lib/paypalUtils';
 import Constants from '../../../constants';
 
@@ -77,9 +77,9 @@ class BillingPayment extends React.Component {
           <button className="subscriber-back-button" type="button">
             <div className="billing-payment-back-button-container">
               <img
-                className="button right-arrow-button-flipped"
-                src={RightArrow}
-                alt="right arrow"
+                className="button left-arrow-button"
+                src={LeftArrow}
+                alt="left arrow"
               />
               <label>Back</label>
             </div>

--- a/src/styles/GeneralOwnerDashboard.css
+++ b/src/styles/GeneralOwnerDashboard.css
@@ -92,11 +92,10 @@ button {
   opacity: 0.8;
 }
 
-.right-arrow-button-flipped {
+.left-arrow-button {
   width: 4vh;
-  transform: scaleX(-1);
 }
 
-.right-arrow-button-flipped:hover {
+.left-arrow-button:hover {
   opacity: 0.8;
 }


### PR DESCRIPTION
[//]: # "These comments meant for your reference, they are invisible and don't need to be deleted"

## What's new in this PR?
[//]: # '####### YOUR ANSWER BELOW ###########'

I updated two of the arrows in the Subscriber dashboard and one in the General Owner dashboard that used the class `right-arrow-button-flipped` to instead use the `left_arrow.png` and added a `left-arrow-button` CSS class.




[//]: # '############## END ##################'

### How to Review

Checkout the subscriber dashboard `/billpayment` screen and the `/billing?view=all` screen as well as the "buy shares" screen for General Owners to ensure the arrows are facing the right way and are correctly proportioned.

[//]: # 'The order in which to review files and 
what to expect when testing locally'
[//]: # '####### YOUR ANSWER BELOW ###########'






[//]: # '############## END ##################'

### Related PRs

[//]: # "Optional - related PRs you're waiting on
/ PRs that will conflict, etc"
[//]: # '####### YOUR ANSWER BELOW ###########'






[//]: # '############## END ##################'

### Next steps

[//]: # "What doesn't work yet, what's NOT in this 
PR/has to be done "
[//]: # '####### YOUR ANSWER BELOW ###########'

Note: I think the left arrow png is one pixel shorter in width than the right arrow png. 




[//]: # '############## END ##################'

### Screenshots
[//]: # '#### YOUR SCREENSHOTS BELOW ########'






[//]: # '############## END ##################'

### Design Status
[//]: # 'If this is a frontend PR, what is the expected 
status of the UI in this PR (lo, mid, high- fi?'
[//]: # '####### LOFI/MIDFI/HIFI ###########'






[//]: # '############## END ##################'

CC: @dfangshuo
