### PR TITLE
[Easy] Allow users to quit onboarding

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -15,8 +15,33 @@ import SettingsDropdown from './SettingsDropdown';
 class NavBar extends React.PureComponent {
   render() {
     const { credentials, pathname, history } = this.props;
-    const displayNavbar = isSignedIn(credentials) && !isOnboarding(credentials);
 
+    // if onboarding
+    if (isOnboarding(credentials)) {
+      return (
+        <div className="nav-bar">
+          <a href="/">
+            <img
+              className="logo"
+              src={Logo}
+              alt="People Power Solar Cooperative Logo"
+            />
+          </a>
+          <nav>
+            {isSignedIn(credentials) && (
+              <ul>
+                <div className="dropdown-safety-box" />
+                <li className="nav-item dropdown-container">
+                  <SettingsDropdown history={history} />
+                </li>
+              </ul>
+            )}
+          </nav>
+        </div>
+      );
+    }
+
+    // else, if is signed in and DONE with onboarding
     return (
       <div className="nav-bar">
         <a href="/">
@@ -27,7 +52,7 @@ class NavBar extends React.PureComponent {
           />
         </a>
         <nav>
-          {displayNavbar && (
+          {isSignedIn(credentials) && (
             <ul>
               <li
                 className={`${

--- a/src/screens/onboarding/steps/PaymentDetailsStep.js
+++ b/src/screens/onboarding/steps/PaymentDetailsStep.js
@@ -124,6 +124,7 @@ class PaymentDetailsStep extends React.Component {
                     name="isReceivingDividends"
                     className="payment-dividends-radio"
                     value
+                    onChange={this.handleChangeDividends}
                   />
                   <label htmlFor="" className="payment-dividends-choice">
                     Yes, I’d like dividends, thank you!


### PR DESCRIPTION
[//]: # "These comments meant for your reference, they are invisible and don't need to be deleted"

## What's new in this PR?

[//]: # '####### YOUR ANSWER BELOW ###########'


Added functionality to allow users to logout during onboarding

![image](https://user-images.githubusercontent.com/28598778/80781747-216f5d80-8ba6-11ea-8b99-d522dc4c9385.png)

Right now - once a user signs in, they would have to manually click back all the way if they want to quit  onboarding, not ideal

[//]: # '############## END ##################'

### How to Review

[//]: # 'The order in which to review files and 
what to expect when testing locally'
[//]: # '####### YOUR ANSWER BELOW ###########'
[//]: # '############## END ##################'

### Related PRs

[//]: # "Optional - related PRs you're waiting on
/ PRs that will conflict, etc"
[//]: # '####### YOUR ANSWER BELOW ###########'
[//]: # '############## END ##################'

### Next steps

[//]: # "What doesn't work yet, what's NOT in this 
PR/has to be done "
[//]: # '####### YOUR ANSWER BELOW ###########'
[//]: # '############## END ##################'

### Screenshots

[//]: # '#### YOUR SCREENSHOTS BELOW ########'
[//]: # '############## END ##################'

### Design Status

[//]: # 'If this is a frontend PR, what is the expected 
status of the UI in this PR (lo, mid, high- fi?'
[//]: # '####### LOFI/MIDFI/HIFI ###########'
[//]: # '############## END ##################'

CC: @dfangshuo
