### PR TITLE
[2] Fixed Login Loading State (and others)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ import AdminDashboard from './screens/admin/AdminDashboard';
 import UserProfile from './screens/shared/UserProfile';
 import ErrorPage from './screens/general/ErrorPage';
 import './styles/App.css';
-import { refreshUserData } from './lib/redux/userData';
+import { refreshUserData, clearUserData } from './lib/redux/userData';
 import { history } from './lib/redux/store';
 import {
   isGeneralOwner,
@@ -31,15 +31,23 @@ import SuperAdminDashboard from './screens/admin/SuperAdminDashboard';
 import BillingPayment from './screens/subscriber/components/BillingPayment';
 import PPRoute from './components/PPRoute';
 import FeedbackButton from './components/FeedbackButton';
+import { getOwnerById } from './lib/airtable/request';
 
 class App extends React.Component {
-  componentDidMount() {
+  async componentDidMount() {
     const { owner } = this.props;
     // TODO: check that airlock session token is valid
 
     // If userLogin info is in Redux, fetch latest version
     if (owner) {
-      refreshUserData(owner.id);
+      try {
+        await getOwnerById(owner.id);
+        refreshUserData(owner.id);
+      } catch (e) {
+        console.log('Session Expired');
+        clearUserData();
+        history.push('/');
+      }
     }
   }
 

--- a/src/components/SettingsDropdown.js
+++ b/src/components/SettingsDropdown.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Gear from '../assets/settings.png';
 import { logoutUser } from '../lib/airlock/airlock';
+import LoadingComponent from './LoadingComponent';
 
 class SettingsDropdown extends React.Component {
   constructor(props) {
@@ -25,6 +26,10 @@ class SettingsDropdown extends React.Component {
   };
 
   render() {
+    const { loading } = this.state;
+    if (loading) {
+      return <LoadingComponent />;
+    }
     return (
       <div className="settings-dropdown inline">
         <img className="nav-item-gear" alt="nav item gear" src={Gear} />

--- a/src/components/SettingsDropdown.js
+++ b/src/components/SettingsDropdown.js
@@ -2,21 +2,26 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Gear from '../assets/settings.png';
 import { logoutUser } from '../lib/airlock/airlock';
-import { setAppIsLoading } from '../lib/redux/userData';
 
-class SettingsDropdown extends React.PureComponent {
+class SettingsDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: false
+    };
+  }
+
   handleLogoutClick = async () => {
-    setAppIsLoading(true);
+    this.setState({ loading: true });
     const { history } = this.props;
     const logOutSuccess = await logoutUser();
     if (logOutSuccess) {
-      setAppIsLoading(false);
       history.push('/');
     } else {
-      setAppIsLoading(false);
       // TODO: Display error to user (also wonder if there's a way to encapsulate this logic in auth.js)
       console.warn('Logout failed');
     }
+    this.setState({ loading: true });
   };
 
   render() {

--- a/src/lib/redux/userData.js
+++ b/src/lib/redux/userData.js
@@ -8,9 +8,7 @@ import { store } from './store';
 import {
   saveUserData,
   deauthenticateAndClearUserData,
-  setLoadingForUserData,
-  setLoading,
-  unsetLoading
+  setLoadingForUserData
 } from './userDataSlice';
 import {
   clearAnnouncements,
@@ -18,14 +16,6 @@ import {
   setLoadingForAnnouncements
 } from './communitySlice';
 import { getCredentials } from '../credentials';
-
-const setAppIsLoading = isLoading => {
-  if (isLoading) {
-    store.dispatch(setLoading());
-  } else {
-    store.dispatch(unsetLoading());
-  }
-};
 
 // Function takes in an ownerId and fetches the latest owner object and all associated user data
 const refreshUserData = async (ownerId, loadSilently = false) => {
@@ -77,4 +67,4 @@ const clearUserData = () => {
   store.dispatch(clearAnnouncements());
 };
 
-export { refreshUserData, clearUserData, setAppIsLoading };
+export { refreshUserData, clearUserData };

--- a/src/lib/redux/userDataSlice.js
+++ b/src/lib/redux/userDataSlice.js
@@ -43,20 +43,12 @@ const userDataSlice = createSlice({
 
     deauthenticateAndClearUserData() {
       return { ...initialState };
-    },
-    setLoading(state, _) {
-      state.isLoading = true;
-    },
-    unsetLoading(state, _) {
-      state.isLoading = false;
     }
   }
 });
 
 export const {
   setLoadingForUserData,
-  setLoading,
-  unsetLoading,
   saveUserData,
   deauthenticateAndClearUserData
 } = userDataSlice.actions;

--- a/src/screens/auth/Login.js
+++ b/src/screens/auth/Login.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { loginUser } from '../../lib/airlock/airlock';
-import { setAppIsLoading } from '../../lib/redux/userData';
 import '../../styles/Login.css';
 import '../../styles/main.css';
 import Constants from '../../constants';
 import ErrorIcon from '../../assets/error.svg';
+import LoadingComponent from '../../components/LoadingComponent';
 
 class Login extends React.Component {
   constructor(props) {
@@ -12,7 +12,8 @@ class Login extends React.Component {
     this.state = {
       email: '',
       passwordHash: '',
-      showLoginError: true
+      loading: false,
+      showLoginError: false
     };
   }
 
@@ -21,7 +22,6 @@ class Login extends React.Component {
   };
 
   handlePasswordChange = event => {
-    // TODO: Hash the password locally
     this.setState({ passwordHash: event.target.value });
   };
 
@@ -31,29 +31,28 @@ class Login extends React.Component {
   };
 
   handleSubmit = async evt => {
-    setAppIsLoading(true);
+    this.setState({ loading: true });
     const { email, passwordHash } = this.state;
     evt.preventDefault();
     try {
       const res = await loginUser(email, passwordHash);
       if (res.found && res.match) {
-        setAppIsLoading(false);
         this.segueToHome(evt);
       } else {
-        setAppIsLoading(false);
         this.setState({
-          showLoginError: false
+          showLoginError: true,
+          loading: false
         });
       }
     } catch (err) {
-      setAppIsLoading(false);
+      this.setState({ loading: false });
       console.error(err);
     }
   };
 
   toggleValidColor() {
     const { showLoginError } = this.state;
-    return showLoginError ? 'b-is-valid' : 'b-is-not-valid';
+    return showLoginError ? 'b-is-not-valid' : 'b-is-valid';
   }
 
   segueToHome(evt) {
@@ -64,7 +63,11 @@ class Login extends React.Component {
   }
 
   render() {
-    const { email, passwordHash, showLoginError } = this.state;
+    const { email, passwordHash, showLoginError, loading } = this.state;
+
+    if (loading) {
+      return <LoadingComponent />;
+    }
     return (
       <div className="center card flex column">
         <h1 className="t-center login-header">Welcome back!</h1>
@@ -104,7 +107,7 @@ class Login extends React.Component {
             </button>
           </div>
         </form>
-        {showLoginError ? (
+        {!showLoginError ? (
           '\u00A0'
         ) : (
           <div className="error-container mt-15">

--- a/src/screens/onboarding/Onboarding.js
+++ b/src/screens/onboarding/Onboarding.js
@@ -8,13 +8,13 @@ import {
   toggleValidColor,
   validateFieldSync
 } from '../../lib/onboardingUtils';
-import { setAppIsLoading } from '../../lib/redux/userData';
 import ProgressBar from './components/ProgressBar';
 import Constants from '../../constants';
 import {
   getPledgeInviteById,
   updatePledgeInvite
 } from '../../lib/airtable/request';
+import LoadingComponent from '../../components/LoadingComponent';
 
 const { GENERAL_OWNER, PLEDGE_INVITE_USED } = Constants;
 
@@ -31,7 +31,8 @@ class Onboarding extends React.Component {
         isReceivingDividends: true,
         numberOfShares: 1
       },
-      errors: {}
+      errors: {},
+      loading: false
     };
   }
 
@@ -109,7 +110,7 @@ class Onboarding extends React.Component {
     });
     this.setState({ errors: newErrors });
     if (!foundErrors) {
-      setAppIsLoading(true);
+      this.setState({ loading: true });
       // Create/Update specific owner fields
       // State should be refreshed when data is successfully pulled from redux
 
@@ -129,7 +130,7 @@ class Onboarding extends React.Component {
       }
 
       await updateOwnerFields(newOwner, fieldsToUpdate);
-      setAppIsLoading(false);
+      this.setState({ loading: false });
     }
   };
 
@@ -212,10 +213,13 @@ class Onboarding extends React.Component {
 
   render() {
     const { history } = this.props;
-    const { owner, errors } = this.state;
+    const { owner, errors, loading } = this.state;
     const stepData = OnboardingData[owner.onboardingStep];
     const StepComponent = stepData.component;
     const showStyles = owner.onboardingStep > 0;
+    if (loading) {
+      return <LoadingComponent />;
+    }
     return (
       <div
         className={showStyles ? 'flex onboarding-col template-center w-70' : ''}


### PR DESCRIPTION
[//]: # "These comments meant for your reference, they are invisible and don't need to be deleted"

## What's new in this PR?

[//]: # '####### YOUR ANSWER BELOW ###########'

- Fixed bug where error wasn't showing after login
- Replaced all cases of `setAppIsLoading` with a local `loading` state variable. 

I didn't realize it then, but the Redux loading variable should only be used when the redux data isn't in the store. The reason is, when redux's loading variable is set, it unloads the entire component, which resets all the state variables and is actually a memory leak. 

Instead, if you want a loading animation to happen in a component for any reason _besides_ data not being in redux yet, you should display it manually

[//]: # '############## END ##################'

### How to Review

[//]: # 'The order in which to review files and 
what to expect when testing locally'
[//]: # '####### YOUR ANSWER BELOW ###########'
[//]: # '############## END ##################'

### Related PRs

[//]: # "Optional - related PRs you're waiting on
/ PRs that will conflict, etc"
[//]: # '####### YOUR ANSWER BELOW ###########'

Branches off of #181 

[//]: # '############## END ##################'

### Next steps

[//]: # "What doesn't work yet, what's NOT in this 
PR/has to be done "
[//]: # '####### YOUR ANSWER BELOW ###########'
[//]: # '############## END ##################'

### Screenshots

[//]: # '#### YOUR SCREENSHOTS BELOW ########'
[//]: # '############## END ##################'

### Design Status

[//]: # 'If this is a frontend PR, what is the expected 
status of the UI in this PR (lo, mid, high- fi?'
[//]: # '####### LOFI/MIDFI/HIFI ###########'
[//]: # '############## END ##################'

CC: @dfangshuo
